### PR TITLE
Update parameter annotation in RetrieveResponseGeneralData

### DIFF
--- a/src/Responses/Info/RetrieveResponseGeneralData.php
+++ b/src/Responses/Info/RetrieveResponseGeneralData.php
@@ -29,7 +29,7 @@ final class RetrieveResponseGeneralData
     }
 
     /**
-     * @param  array{cui: int, data: string, denumire: string, adresa: string, nrRegCom: string, telefon: string, fax: string, codPostal: string, act: string, stare_inregistrare: string, data_inregistrare: string, cod_CAEN: string, iban: string, statusRO_e_Factura: bool, organFiscalCompetent: string, forma_de_proprietate: string, forma_organizare: string, forma_juridica: string}  $attributes
+     * @param  array{cui: int, data: string, denumire: string, adresa: string, nrRegCom: string, telefon: string, fax: string, codPostal: string, act: string, stare_inregistrare: string, data_inregistrare: string, cod_CAEN: string, iban: string, statusRO_e_Factura: bool, organFiscalCompetent: string }  $attributes
      */
     public static function from(array $attributes): self
     {


### PR DESCRIPTION
The docblock parameter annotation in the `from` method of `RetrieveResponseGeneralData` class has been updated. The 'forma_de_proprietate', 'forma_organizare', and 'forma_juridica' items were removed from the array in the annotation.