### PR TITLE
fix: TaxIdentificationNumberNotFoundException n/a anymore

### DIFF
--- a/src/Transporters/HttpTransporter.php
+++ b/src/Transporters/HttpTransporter.php
@@ -78,13 +78,13 @@ class HttpTransporter implements TransporterContract
 
         }
 
-        if (! array_key_exists('notFound', $response) && ! array_key_exists('Errors', $response)) {
-            return $response;
-        }
+        // if (! array_key_exists('notFound', $response) && ! array_key_exists('Errors', $response)) {
+        //     return $response;
+        // }
 
-        if ($response['notFound'] !== []) {
-            throw new TaxIdentificationNumberNotFoundException();
-        }
+        // if ($response['notFound'] !== []) {
+        //     throw new TaxIdentificationNumberNotFoundException();
+        // }
 
         return $response;
     }


### PR DESCRIPTION
I believe TaxIdentificationNumberNotFoundException exception it's not really needed anymore in HttpTransporter because it conflicts with Anaf\Resources\Info::create()